### PR TITLE
Build with newer Emscripten and different flags

### DIFF
--- a/box2d-wasm/README.dev.md
+++ b/box2d-wasm/README.dev.md
@@ -12,8 +12,6 @@ Navigate to `<repository root>/box2d-wasm`, then:
 export TARGET_TYPE=Debug
 export EMSCRIPTEN="${EMSCRIPTEN:-"$(realpath "$(dirname $(realpath "$(which emcc)"))/../libexec")"}"
 export PYTHON="${PYTHON:-"$(which python3)"}"
-# if you're developing in this monorepo, you'll be testing your changes with integration-test, which doesn't use the UMD output
-export SKIP_UMD_BUILD=1
 ./build_all.sh
 ```
 

--- a/box2d-wasm/README.dev.md
+++ b/box2d-wasm/README.dev.md
@@ -2,7 +2,7 @@
 
 Ensure that you have a recent [emscripten](https://emscripten.org/) installed.
 
-This build process is known to work with emscripten 2.0.5.
+**Requires Emscripten 2.0.16 or higher.**
 
 ### Overview
 

--- a/box2d-wasm/build_makefile.sh
+++ b/box2d-wasm/build_makefile.sh
@@ -13,30 +13,9 @@ fi
 
 >&2 echo -e '\nGenerating Makefile with emcmake'
 
-# if we were to pass -DCMAKE_BUILD_TYPE="$TARGET_TYPE" to emcmake,
-# emcmake would enforce the following overrides (see build/CMakeCache.txt after running emcmake)
-#   CMAKE_CXX_FLAGS_DEBUG:STRING=-g
-#   CMAKE_CXX_FLAGS_MINSIZEREL:STRING=-DNDEBUG -Os
-#   CMAKE_CXX_FLAGS_RELEASE:STRING=-DNDEBUG -O2
-#   CMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=-DNDEBUG -O2
-# these flags would be applied *after* ours, which means they would have precedence.
-# as such: we do *not* set CMAKE_BUILD_TYPE, because we wish for higher optimization (O3) on Release builds
-# see how the flags get resolved in build/src/CMakeFiles/box2d.dir/flags.make
-CMAKE_CXX_FLAGS=()
-RELEASE_FLAGS_NOMINAL=(-DNDEBUG -O3)
-
 case "$TARGET_TYPE" in
-  RelWithDebInfo)
-    # -flto can succeed here, but causes the emcc after this to fail during wasm-emscripten-finalize (possibly due to source maps)
-    CMAKE_CXX_FLAGS=(${RELEASE_FLAGS_NOMINAL[@]} -g)
+  RelWithDebInfo | Release | Debug)
     ;;
-  Release)
-    CMAKE_CXX_FLAGS=(${RELEASE_FLAGS_NOMINAL[@]} -flto)
-    ;;
-  Debug)
-    CMAKE_CXX_FLAGS=(-g)
-    ;;
-
   *)
     >&2 echo -e "${Red}TARGET_TYPE not set.${NC}"
     >&2 echo -e "Please set TARGET_TYPE to 'Debug', 'Release', or 'RelWithDebInfo'. For example, with:"
@@ -47,4 +26,4 @@ esac
 >&2 echo -e "TARGET_TYPE is $TARGET_TYPE"
 
 set -x
-emcmake cmake -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" ../../box2d -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_TESTBED=OFF
+emcmake cmake -DCMAKE_BUILD_TYPE="$TARGET_TYPE" ../../box2d -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_TESTBED=OFF

--- a/box2d-wasm/build_wasm.sh
+++ b/box2d-wasm/build_wasm.sh
@@ -25,7 +25,6 @@ EMCC_OPTS=(
   -s SUPPORT_LONGJMP=0
   -s EXPORTED_FUNCTIONS=_malloc,_free
   -s ALLOW_MEMORY_GROWTH=1
-  -s WASM=2
   )
 RELEASE_OPTS=(-O3)
 
@@ -87,20 +86,20 @@ mkdir -p "$UMD_DIR" "$ES_DIR"
 LINK_OPTS=(--post-link "$BARE_WASM" --post-js "$DIR/glue_stub.js" ${EMCC_OPTS[@]})
 
 ES_FILE="$ES_DIR/$BASENAME.js"
->&2 echo -e "${Blue}Building ES module, $ES_DIR/$BASENAME.{js,wasm{,.js}}${NC}"
+>&2 echo -e "${Blue}Building ES module, $ES_DIR/$BASENAME.{js,wasm}${NC}"
 set -x
 emcc "${LINK_OPTS[@]}" -s EXPORT_ES6=1 -o "$ES_FILE"
 { set +x; } 2>&-
->&2 echo -e "${Green}Successfully built $ES_DIR/$BASENAME.{js,wasm{,.js}}${NC}\n"
+>&2 echo -e "${Green}Successfully built $ES_DIR/$BASENAME.{js,wasm}${NC}\n"
 
 UMD_FILE="$UMD_DIR/$BASENAME.js"
 if [ "$BUILD_UMD_FROM_SCRATCH" = "1" ]; then
-  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm{,.js}} from scratch${NC}"
+  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm} from scratch${NC}"
   set -x
   emcc "${LINK_OPTS[@]}" -o "$UMD_FILE"
   { set +x; } 2>&-
 else
-  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm{,.js}} by replacing header & footer of ES module${NC}"
+  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm} by replacing header & footer of ES module${NC}"
   escape_for_sed_replace () {
     echo "$1" | sed -e 's/&/\\\&/g' -e '$!s/$/\\n/' | tr -d '\n'
   }
@@ -122,6 +121,6 @@ else
   UMD_FOOTER_ESCAPED=`escape_for_sed_replace "$UMD_FOOTER"`
 
   sed -e "s/^$ES6_HEADER$/$UMD_HEADER_ESCAPED/" -e "s/^$ES6_FOOTER$/$UMD_FOOTER_ESCAPED/" "$ES_FILE" > "$UMD_FILE"
-  cp "$ES_DIR/$BASENAME.wasm"{,.js} "$UMD_DIR"
+  cp "$ES_DIR/$BASENAME.wasm" "$UMD_DIR"
 fi
->&2 echo -e "${Green}Successfully built $UMD_DIR/$BASENAME.{js,wasm{,.js}}${NC}\n"
+>&2 echo -e "${Green}Successfully built $UMD_DIR/$BASENAME.{js,wasm}${NC}\n"

--- a/box2d-wasm/build_wasm.sh
+++ b/box2d-wasm/build_wasm.sh
@@ -25,6 +25,7 @@ EMCC_OPTS=(
   -s SUPPORT_LONGJMP=0
   -s EXPORTED_FUNCTIONS=_malloc,_free
   -s ALLOW_MEMORY_GROWTH=1
+  -s WASM=2
   )
 RELEASE_OPTS=(-O3)
 
@@ -85,20 +86,42 @@ mkdir -p "$UMD_DIR" "$ES_DIR"
 
 LINK_OPTS=(--post-link "$BARE_WASM" --post-js "$DIR/glue_stub.js" ${EMCC_OPTS[@]})
 
-if [ "$SKIP_UMD_BUILD" = "1" ]; then
-  >&2 echo -e "${Green}Skipped UMD build because we gotta go fast${NC}"
-else
-  UMD_FILE="$UMD_DIR/$BASENAME.js"
-  >&2 echo -e "${Blue}Building UMD module, $UMD_FILE${NC}"
-  set -x
-  emcc "${LINK_OPTS[@]}" -o "$UMD_FILE"
-  { set +x; } 2>&-
-  >&2 echo -e "${Green}Successfully built $UMD_FILE${NC}\n"
-fi
-
 ES_FILE="$ES_DIR/$BASENAME.js"
->&2 echo -e "${Blue}Building ES module, $ES_FILE${NC}"
+>&2 echo -e "${Blue}Building ES module, $ES_DIR/$BASENAME.{js,wasm{,.js}}${NC}"
 set -x
 emcc "${LINK_OPTS[@]}" -s EXPORT_ES6=1 -o "$ES_FILE"
 { set +x; } 2>&-
->&2 echo -e "${Green}Successfully built $ES_FILE${NC}"
+>&2 echo -e "${Green}Successfully built $ES_DIR/$BASENAME.{js,wasm{,.js}}${NC}\n"
+
+UMD_FILE="$UMD_DIR/$BASENAME.js"
+if [ "$BUILD_UMD_FROM_SCRATCH" = "1" ]; then
+  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm{,.js}} from scratch${NC}"
+  set -x
+  emcc "${LINK_OPTS[@]}" -o "$UMD_FILE"
+  { set +x; } 2>&-
+else
+  >&2 echo -e "${Blue}Building UMD module, $UMD_DIR/$BASENAME.{js,wasm{,.js}} by replacing header & footer of ES module${NC}"
+  escape_for_sed_replace () {
+    echo "$1" | sed -e 's/&/\\\&/g' -e '$!s/$/\\n/' | tr -d '\n'
+  }
+
+  ES6_HEADER='  var _scriptDir = import.meta.url;'
+  UMD_HEADER="  var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
+  if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;"
+  UMD_HEADER_ESCAPED=`escape_for_sed_replace "$UMD_HEADER"`
+
+  ES6_FOOTER='export default Box2D;'
+  UMD_FOOTER="if (typeof exports === 'object' && typeof module === 'object')
+      module.exports = Box2D;
+    else if (typeof define === 'function' && define['amd'])
+      define([], function() { return Box2D; });
+    else if (typeof exports === 'object')
+      exports['Box2D'] = Box2D;
+    
+"
+  UMD_FOOTER_ESCAPED=`escape_for_sed_replace "$UMD_FOOTER"`
+
+  sed -e "s/^$ES6_HEADER$/$UMD_HEADER_ESCAPED/" -e "s/^$ES6_FOOTER$/$UMD_FOOTER_ESCAPED/" "$ES_FILE" > "$UMD_FILE"
+  cp "$ES_DIR/$BASENAME.wasm"{,.js} "$UMD_DIR"
+fi
+>&2 echo -e "${Green}Successfully built $UMD_DIR/$BASENAME.{js,wasm{,.js}}${NC}\n"

--- a/box2d-wasm/build_wasm.sh
+++ b/box2d-wasm/build_wasm.sh
@@ -14,23 +14,48 @@ if ! [[ "$PWD" -ef "$DIR/build" ]]; then
 fi
 
 # we used to use -s ENVIRONMENT=web for a slightly smaller build, until Node.js compatibility was requested in https://github.com/Birch-san/box2d-wasm/issues/8
-EMCC_OPTS=(-s MODULARIZE=1 -s EXPORT_NAME=Box2D -s EXPORT_BINDINGS=1 -s RESERVED_FUNCTION_POINTERS=20 --post-js box2d_glue.js --memory-init-file 0 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS=[] -s EXPORTED_FUNCTIONS="['_malloc','_free']" -fno-rtti -s ALLOW_MEMORY_GROWTH=1)
-
-RELEASE_OPTS_NOMINAL=(-O3)
+EMCC_OPTS=(
+  -fno-rtti
+  -s MODULARIZE=1
+  -s EXPORT_NAME=Box2D
+  -s ALLOW_TABLE_GROWTH=1
+  --post-js box2d_glue.js
+  --memory-init-file 0
+  -s FILESYSTEM=0
+  -s SUPPORT_LONGJMP=0
+  -s EXPORTED_FUNCTIONS=_malloc,_free
+  -s ALLOW_MEMORY_GROWTH=1
+  )
+RELEASE_OPTS=(-O3)
 
 case "$TARGET_TYPE" in
   Debug)
-    FLAVOUR_EMCC_OPTS=(-g4 -s ASSERTIONS=2 -s DEMANGLE_SUPPORT=1)
+    EMCC_OPTS=(
+      ${EMCC_OPTS[@]}
+      -g4
+      -s ASSERTIONS=2
+      -s DEMANGLE_SUPPORT=1
+      )
     ;;
 
   RelWithDebInfo)
     # consider setting --source-map-base if you know where
     # Box2D will be served from.
-    FLAVOUR_EMCC_OPTS=(-g4 ${RELEASE_OPTS_NOMINAL[@]})
+    EMCC_OPTS=(
+      ${EMCC_OPTS[@]}
+      ${RELEASE_OPTS[@]}
+      -g4
+      )
     ;;
   
   Release)
-    FLAVOUR_EMCC_OPTS=(-flto --closure 1 -s IGNORE_CLOSURE_COMPILER_ERRORS=1 ${RELEASE_OPTS_NOMINAL[@]})
+    EMCC_OPTS=(
+      ${EMCC_OPTS[@]}
+      ${RELEASE_OPTS[@]}
+      -flto
+      --closure 1
+      -s IGNORE_CLOSURE_COMPILER_ERRORS=1
+      )
     ;;
   
   *)
@@ -42,13 +67,23 @@ case "$TARGET_TYPE" in
 esac
 >&2 echo -e "TARGET_TYPE is $TARGET_TYPE"
 
-EMCC_COMMAND_NOMINAL=("${EMCC_OPTS[@]}" "${FLAVOUR_EMCC_OPTS[@]}" -I "$DIR/../box2d/include" --post-js "$DIR/glue_stub.js" "$DIR/glue_stub.cpp" bin/libbox2d.a)
 
 BASENAME='Box2D'
+BARE_WASM="$BASENAME.bare.wasm"
+
+>&2 echo -e "${Blue}Building bare WASM${NC}"
+set -x
+emcc "$DIR/glue_stub.cpp" bin/libbox2d.a -I "$DIR/../box2d/include" "${EMCC_OPTS[@]}" --oformat=bare -o "$BARE_WASM"
+{ set +x; } 2>&-
+>&2 echo -e "${Green}Successfully built $BARE_WASM${NC}\n"
 
 UMD_DIR='umd'
 ES_DIR='es'
 mkdir -p "$UMD_DIR" "$ES_DIR"
+
+>&2 echo -e "${Blue}Building post-link targets${NC}"
+
+LINK_OPTS=(--post-link "$BARE_WASM" --post-js "$DIR/glue_stub.js" ${EMCC_OPTS[@]})
 
 if [ "$SKIP_UMD_BUILD" = "1" ]; then
   >&2 echo -e "${Green}Skipped UMD build because we gotta go fast${NC}"
@@ -56,7 +91,7 @@ else
   UMD_FILE="$UMD_DIR/$BASENAME.js"
   >&2 echo -e "${Blue}Building UMD module, $UMD_FILE${NC}"
   set -x
-  emcc "${EMCC_COMMAND_NOMINAL[@]}" -o "$UMD_FILE"
+  emcc "${LINK_OPTS[@]}" -o "$UMD_FILE"
   { set +x; } 2>&-
   >&2 echo -e "${Green}Successfully built $UMD_FILE${NC}\n"
 fi
@@ -64,6 +99,6 @@ fi
 ES_FILE="$ES_DIR/$BASENAME.js"
 >&2 echo -e "${Blue}Building ES module, $ES_FILE${NC}"
 set -x
-emcc "${EMCC_COMMAND_NOMINAL[@]}" -s EXPORT_ES6=1 -o "$ES_FILE"
+emcc "${LINK_OPTS[@]}" -s EXPORT_ES6=1 -o "$ES_FILE"
 { set +x; } 2>&-
 >&2 echo -e "${Green}Successfully built $ES_FILE${NC}"

--- a/box2d-wasm/glue_stub.js
+++ b/box2d-wasm/glue_stub.js
@@ -286,11 +286,11 @@ Module['toFloatArray'] = (floats) => {
  * @return {number} Size of the element which ctor constructs
  */
 Module['sizeof'] = (ctor) => {
-  const { ptr, __destroy__ } = new ctor();
-  const { ptr: ptr2, __destroy__: __destroy__2 } = new ctor();
-  const size = ptr2-ptr;
-  __destroy__2();
-  __destroy__();
+  const a = new ctor();
+  const b = new ctor();
+  const size = b.ptr-a.ptr;
+  b.__destroy__();
+  a.__destroy__();
   return size;
 };
 

--- a/box2d-wasm/package.json
+++ b/box2d-wasm/package.json
@@ -10,10 +10,8 @@
     "build/Box2D.d.ts",
     "build/es/Box2D.js",
     "build/es/Box2D.wasm",
-    "build/es/Box2D.wasm.js",
     "build/umd/Box2D.js",
-    "build/umd/Box2D.wasm",
-    "build/umd/Box2D.wasm.js"
+    "build/umd/Box2D.wasm"
   ],
   "types": "Box2DModule.d.ts",
   "repository": {

--- a/box2d-wasm/package.json
+++ b/box2d-wasm/package.json
@@ -10,8 +10,10 @@
     "build/Box2D.d.ts",
     "build/es/Box2D.js",
     "build/es/Box2D.wasm",
+    "build/es/Box2D.wasm.js",
     "build/umd/Box2D.js",
-    "build/umd/Box2D.wasm"
+    "build/umd/Box2D.wasm",
+    "build/umd/Box2D.wasm.js"
   ],
   "types": "Box2DModule.d.ts",
   "repository": {


### PR DESCRIPTION
## Seems to be more performant now

`b2World#Step` runs `~7x` faster for me now. Previously, the [fluid simulation](https://birchlabs.co.uk/box2d-wasm-liquidfun/) took `18~20ms` to do a world step, but now it completes in `2~3ms`

Perhaps because of loop unrolling? Or something else? There are far fewer stack frames now. b2World#Step goes 11 stack frames deep, where previously it went as deep as 16.

## Smaller

Shaved 90kB off the WASM. Maybe this is because of eliminating longjmp support?

Before:

349 kB Box2D.wasm  
405 kB Box2D.js  
= 754 kB

After:

259 kB Box2D.wasm  
405 kB Box2D.js  
= 664 kB

## Faster UMD build

Originally I used a variable to skip UMD build whenever I wasn't preparing releases, but it really is identical to the ES build, save for preamble/postamble. We now create a UMD build instantly by doing a string replace over the ES build.

## Build on Emscripten 2.0.16

A [few reasons](https://emscripten.org/docs/introducing_emscripten/release_notes.html)

### 2.0.16

> - Lists that are passed on the command line can now skip the opening and closing braces, allowing for simpler, more readable settings.  e.g. `-s EXPORTED_FUNCTIONS=foo,bar`

### 2.0.14

> - Clang now performs loop unrolling when targeting WebAssembly at -O2 and higher. It can be disabled using `-fno-unroll-loops`.

This may be why it runs faster now.

### 2.0.12

> - Stop overriding CMake default flags based on build type. This will result in builds that are more like CMake does on other platforms. You may notice that `RelWithDebInfo` will now include debug info (it did not before, which appears to have been an error), and that `Release` will use `-O3` instead of `-O2` (which is a better choice anyhow). (#13083)

### 2.0.9

> - Added experimental support for using emscripten as a post link tool.  In this case the input to emscripten is a single wasm file (for example the output of `wasm-ld`).  When emcc is run with `--post-link` it will take a wasm file as input that perform all the normal post link steps such as finalizing and optimizing the wasm file and generating the JavaScript and/or html that will run it.

### 2.0.7

> - When `-s SUPPORT_LONGJMP=0` is passed to disable longjmp, do not run the LLVM wasm backend path that handles longjmp. Before this only affected linking, and now the flag gives you the ability to affect codegen at compile time too. This is necessary if one does not want any invokes generated for longjmp at all.

## Change flags

### Removal

`-s EXPORT_BINDINGS=1` [No longer needed](https://github.com/emscripten-core/emscripten/blob/64011e101e56cf713825d2d6e0a74a41f95d96c8/src/settings.js#L2030).

`-s RESERVED_FUNCTION_POINTERS=20` [removed in favour of `ALLOW_TABLE_GROWTH`](https://github.com/emscripten-core/emscripten/blob/64011e101e56cf713825d2d6e0a74a41f95d96c8/src/settings.js#L1992)

`-s NO_EXIT_RUNTIME=1` removed because [`EXIT_RUNTIME = 0` by default](https://github.com/emscripten-core/emscripten/blob/64011e101e56cf713825d2d6e0a74a41f95d96c8/src/settings.js#L102)

`-s EXPORTED_RUNTIME_METHODS=[]` removed because [`EXPORTED_RUNTIME_METHODS = []` by default](https://github.com/emscripten-core/emscripten/blob/64011e101e56cf713825d2d6e0a74a41f95d96c8/src/settings.js#L800)

### Simplification

`-s NO_FILESYSTEM=1` simplified to `-s FILESYSTEM=0`

### Addition

`-s SUPPORT_LONGJMP=0` since I didn't notice Box2D's C++ source make any use of exception-handling. Nothing went bang.