### PR TITLE
SIMD

### DIFF
--- a/box2d-wasm/.gitignore
+++ b/box2d-wasm/.gitignore
@@ -1,2 +1,5 @@
 /build/
 /node_modules/
+# distributions made with npm pack
+*.tgz
+*.tar.gz

--- a/box2d-wasm/Box2DModule.d.ts
+++ b/box2d-wasm/Box2DModule.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="emscripten" />
 /// <reference path="Box2DModuleAugmentations.d.ts" />
-/// <reference path="build/Box2D.d.ts" />
+/// <reference path="build/common/Box2D.d.ts" />
 declare module "box2d-wasm" {
   const Box2DFactory: EmscriptenModuleFactory<typeof Box2D & EmscriptenModule>;
   export = Box2DFactory;

--- a/box2d-wasm/Box2DModuleAugmentations.d.ts
+++ b/box2d-wasm/Box2DModuleAugmentations.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="build/Box2D.d.ts" />
+/// <reference path="build/common/Box2D.d.ts" />
 declare namespace Box2D {
   /**
    * merge in an extra {@link b2RopeDef} property; we were unable to describe this (pointer to array of floats)

--- a/box2d-wasm/LICENSE.zlib.txt
+++ b/box2d-wasm/LICENSE.zlib.txt
@@ -1,0 +1,19 @@
+Zlib License
+
+Copyright (c) 2020 Alex Birch
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/box2d-wasm/build_all.sh
+++ b/box2d-wasm/build_all.sh
@@ -15,31 +15,58 @@ if ! [[ "$PWD" -ef "$DIR" ]]; then
   exit 1
 fi
 
-mkdir -p build
-pushd build > /dev/null
-
-set -x
-../build_makefile.sh
-{ set +x; } 2>&-
-
->&2 echo -e '\nCompiling C++ to LLVM IR (creates ./build/bin/libbox2d.a archive)'
-set -x
-emmake make
-{ set +x; } 2>&-
->&2 echo
+mkdir -p "build/common"
+pushd "build/common"
 
 # use Box2D.idl to create ./box2d_glue.{js,cpp} for invoking functionality from libbox2d
 set -x
-../build_idl_bindings.sh
-{ set +x; } 2>&-
->&2 echo
-
-# generate Box2D_*.{wasm,js} from glue code + libbox2d.a
-set -x
-../build_wasm.sh
+"$DIR/build_idl_bindings.sh"
 { set +x; } 2>&-
 >&2 echo
 
 set -x
-../build_typings.sh
+"$DIR/build_typings.sh"
 { set +x; } 2>&-
+
+popd
+
+FLAVOUR_NAMES=(vanilla SIMD)
+FLAVOUR_DIRNAMES=(standard simd)
+SIMD_ENABLED=('' 1)
+
+for i in {0..1}
+do
+  FLAVOUR_NAME="${FLAVOUR_NAMES["$i"]}"
+  FLAVOUR_DIRNAME="${FLAVOUR_DIRNAMES["$i"]}"
+
+  # use JUST_SIMD=1 to save time when prototyping
+  if [[ "$JUST_SIMD" = "1" && "$FLAVOUR_NAME" != "simd" ]]; then
+    >&2 echo -e "\nSkipping '$FLAVOUR_NAME' flavour build because JUST_SIMD is set."
+    continue
+  fi
+
+
+  FLAVOUR_DIR="build/flavour/$FLAVOUR_DIRNAME"
+  >&2 echo -e "\nMaking '$FLAVOUR_NAME' flavour in ./$FLAVOUR_DIR directory"
+  mkdir -p "$FLAVOUR_DIR"
+  pushd "$FLAVOUR_DIR"
+
+  set -x
+  SIMD_ENABLED="$SIMD_ENABLED" "$DIR/build_makefile.sh"
+  { set +x; } 2>&-
+
+  >&2 echo -e '\nCompiling C++ to LLVM IR (creates ./build/bin/libbox2d.a archive)'
+  set -x
+  emmake make
+  { set +x; } 2>&-
+  >&2 echo
+
+  # generate Box2D_*.{wasm,js} from glue code + libbox2d.a
+  set -x
+  SIMD_ENABLED="$SIMD_ENABLED" "$DIR/build_wasm.sh"
+  { set +x; } 2>&-
+
+  >&2 echo -e "Completed '$FLAVOUR_NAME' flavour"
+
+  popd
+done    

--- a/box2d-wasm/build_all.sh
+++ b/box2d-wasm/build_all.sh
@@ -30,29 +30,26 @@ set -x
 
 popd
 
-FLAVOUR_NAMES=(vanilla SIMD)
-FLAVOUR_DIRNAMES=(standard simd)
-SIMD_ENABLED=('' 1)
+FLAVOURS=(standard simd)
 
 for i in {0..1}
 do
-  FLAVOUR_NAME="${FLAVOUR_NAMES["$i"]}"
-  FLAVOUR_DIRNAME="${FLAVOUR_DIRNAMES["$i"]}"
+  FLAVOUR="${FLAVOURS["$i"]}"
 
   # use JUST_SIMD=1 to save time when prototyping
-  if [[ "$JUST_SIMD" = "1" && "$FLAVOUR_NAME" != "simd" ]]; then
-    >&2 echo -e "\nSkipping '$FLAVOUR_NAME' flavour build because JUST_SIMD is set."
+  if [[ "$JUST_SIMD" = "1" && "$FLAVOUR" != "simd" ]]; then
+    >&2 echo -e "\nSkipping '$FLAVOUR' flavour build because JUST_SIMD is set."
     continue
   fi
 
 
-  FLAVOUR_DIR="build/flavour/$FLAVOUR_DIRNAME"
-  >&2 echo -e "\nMaking '$FLAVOUR_NAME' flavour in ./$FLAVOUR_DIR directory"
+  FLAVOUR_DIR="build/flavour/$FLAVOUR"
+  >&2 echo -e "\nMaking '$FLAVOUR' flavour in ./$FLAVOUR_DIR directory"
   mkdir -p "$FLAVOUR_DIR"
   pushd "$FLAVOUR_DIR"
 
   set -x
-  SIMD_ENABLED="$SIMD_ENABLED" "$DIR/build_makefile.sh"
+  FLAVOUR="$FLAVOUR" "$DIR/build_makefile.sh"
   { set +x; } 2>&-
 
   >&2 echo -e '\nCompiling C++ to LLVM IR (creates ./build/bin/libbox2d.a archive)'
@@ -63,10 +60,10 @@ do
 
   # generate Box2D_*.{wasm,js} from glue code + libbox2d.a
   set -x
-  SIMD_ENABLED="$SIMD_ENABLED" "$DIR/build_wasm.sh"
+  FLAVOUR="$FLAVOUR" "$DIR/build_wasm.sh"
   { set +x; } 2>&-
 
-  >&2 echo -e "Completed '$FLAVOUR_NAME' flavour"
+  >&2 echo -e "Completed '$FLAVOUR' flavour"
 
   popd
 done    

--- a/box2d-wasm/build_idl_bindings.sh
+++ b/box2d-wasm/build_idl_bindings.sh
@@ -6,8 +6,8 @@ Red='\033[0;31m'
 Purple='\033[0;35m'
 NC='\033[0m' # No Color
 
-if ! [[ "$PWD" -ef "$DIR/build" ]]; then
-  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build${NC}"
+if ! [[ "$PWD" -ef "$DIR/build/common" ]]; then
+  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build/common${NC}"
   exit 1
 fi
 

--- a/box2d-wasm/build_makefile.sh
+++ b/box2d-wasm/build_makefile.sh
@@ -6,8 +6,8 @@ Red='\033[0;31m'
 Purple='\033[0;35m'
 NC='\033[0m' # No Color
 
-if ! [[ "$PWD" -ef "$DIR/build" ]]; then
-  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build${NC}"
+if ! [[ "$(dirname "$PWD")" -ef "$DIR/build/flavour" ]]; then
+  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build/flavour/\$FLAVOUR_DIRNAME${NC}"
   exit 1
 fi
 
@@ -25,5 +25,10 @@ case "$TARGET_TYPE" in
 esac
 >&2 echo -e "TARGET_TYPE is $TARGET_TYPE"
 
+CMAKE_CXX_FLAGS=()
+if [[ "$SIMD_ENABLED" = "1" ]]; then
+  CMAKE_CXX_FLAGS=(${CMAKE_CXX_FLAGS[@]} -msimd128)
+fi
+
 set -x
-emcmake cmake -DCMAKE_BUILD_TYPE="$TARGET_TYPE" ../../box2d -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_TESTBED=OFF
+emcmake cmake -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS[@]}" "$DIR/../box2d" -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_TESTBED=OFF

--- a/box2d-wasm/build_makefile.sh
+++ b/box2d-wasm/build_makefile.sh
@@ -6,8 +6,23 @@ Red='\033[0;31m'
 Purple='\033[0;35m'
 NC='\033[0m' # No Color
 
-if ! [[ "$(dirname "$PWD")" -ef "$DIR/build/flavour" ]]; then
-  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build/flavour/\$FLAVOUR_DIRNAME${NC}"
+CMAKE_CXX_FLAGS=()
+case "$FLAVOUR" in
+  standard)
+    ;;
+  simd)
+    CMAKE_CXX_FLAGS=(${CMAKE_CXX_FLAGS[@]} -msimd128)
+    ;;
+  *)
+    >&2 echo -e "${Red}FLAVOUR not set.${NC}"
+    >&2 echo -e "Please set FLAVOUR to 'standard' or 'simd'. For example, with:"
+    >&2 echo -e "${Purple}export FLAVOUR='simd'${NC}"
+    exit 1
+    ;;
+esac
+
+if ! [[ "$PWD" -ef "$DIR/build/flavour/$FLAVOUR" ]]; then
+  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build/flavour/$FLAVOUR${NC}"
   exit 1
 fi
 
@@ -24,11 +39,6 @@ case "$TARGET_TYPE" in
     ;;
 esac
 >&2 echo -e "TARGET_TYPE is $TARGET_TYPE"
-
-CMAKE_CXX_FLAGS=()
-if [[ "$SIMD_ENABLED" = "1" ]]; then
-  CMAKE_CXX_FLAGS=(${CMAKE_CXX_FLAGS[@]} -msimd128)
-fi
 
 set -x
 emcmake cmake -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS[@]}" "$DIR/../box2d" -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_TESTBED=OFF

--- a/box2d-wasm/build_typings.sh
+++ b/box2d-wasm/build_typings.sh
@@ -6,12 +6,12 @@ Red='\033[0;31m'
 Purple='\033[0;35m'
 NC='\033[0m' # No Color
 
-if ! [[ "$PWD" -ef "$DIR/build" ]]; then
-  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build${NC}"
+if ! [[ "$PWD" -ef "$DIR/build/common" ]]; then
+  >&2 echo -e "${Red}This script is meant to be run from <repository_root>/box2d-wasm/build/common${NC}"
   exit 1
 fi
 
-: "${WEBIDL_TO_TS:=../node_modules/webidl-to-ts}"
+: "${WEBIDL_TO_TS:="$DIR/node_modules/webidl-to-ts"}"
 if test -d "${WEBIDL_TO_TS-}"; then
   >&2 echo -e "webidl-to-ts found at: $WEBIDL_TO_TS"
 else
@@ -23,4 +23,4 @@ fi
 
 set -x
 # requires Node 14.0.0 for running ES modules
-exec node --experimental-specifier-resolution=node --harmony "$WEBIDL_TO_TS/dist/index.js" -f ../Box2D.idl -n Box2D -o Box2D.d.ts
+exec node --experimental-specifier-resolution=node --harmony "$WEBIDL_TO_TS/dist/index.js" -f "$DIR/Box2D.idl" -n Box2D -o Box2D.d.ts

--- a/box2d-wasm/entry/es/entry.js
+++ b/box2d-wasm/entry/es/entry.js
@@ -1,11 +1,12 @@
 import { simd } from 'wasm-feature-detect'
 
-export default (async () => {
+export default async (...args) => {
   const hasSIMD = await simd();
-  const module = await (
+  const Box2DModule = await (
     hasSIMD
       ? import('../../build/flavour/simd/es/Box2D.simd.js')
       : import('../../build/flavour/standard/es/Box2D.js')
   );
-  return module;
-})();
+  const { 'default': Box2DFactory } = Box2DModule;
+  return await Box2DFactory(...args);
+};

--- a/box2d-wasm/entry/es/entry.js
+++ b/box2d-wasm/entry/es/entry.js
@@ -1,0 +1,11 @@
+import { simd } from 'wasm-feature-detect'
+
+export default (async () => {
+  const hasSIMD = await simd();
+  const module = await (
+    hasSIMD
+      ? import('../../build/flavour/simd/es/Box2D.simd.js')
+      : import('../../build/flavour/standard/es/Box2D.js')
+  );
+  return module;
+})();

--- a/box2d-wasm/entry/umd/.eslintrc.cjs
+++ b/box2d-wasm/entry/umd/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 2019,
+  },
+  env: {
+    commonjs: true,
+    es6: true
+  }
+}

--- a/box2d-wasm/entry/umd/entry.js
+++ b/box2d-wasm/entry/umd/entry.js
@@ -1,0 +1,12 @@
+// this file will be copied into the build/es folder
+const { simd } = require('wasm-feature-detect');
+
+module.exports = (async () => {
+  const hasSIMD = await simd();
+  const module = (
+    hasSIMD
+      ? require('../../build/flavour/simd/umd/Box2D.simd.js')
+      : require('../../build/flavour/standard/umd/Box2D.js')
+  );
+  return module;
+})();

--- a/box2d-wasm/entry/umd/entry.js
+++ b/box2d-wasm/entry/umd/entry.js
@@ -1,12 +1,11 @@
-// this file will be copied into the build/es folder
 const { simd } = require('wasm-feature-detect');
 
-module.exports = (async () => {
+module.exports = async (...args) => {
   const hasSIMD = await simd();
-  const module = (
+  const Box2DFactory = (
     hasSIMD
       ? require('../../build/flavour/simd/umd/Box2D.simd.js')
       : require('../../build/flavour/standard/umd/Box2D.js')
   );
-  return module;
-})();
+  return Box2DFactory(...args);
+};

--- a/box2d-wasm/glue_stub.cpp
+++ b/box2d-wasm/glue_stub.cpp
@@ -33,7 +33,7 @@ public:
   }
 };
 
-#include "build/box2d_glue.cpp"
+#include "build/common/box2d_glue.cpp"
 
 extern "C" {
 // member functions that we weren't able to describe in WebIDL (e.g. pointer-to-float params)

--- a/box2d-wasm/package.json
+++ b/box2d-wasm/package.json
@@ -2,16 +2,22 @@
   "name": "box2d-wasm",
   "version": "4.1.0",
   "description": "Box2D compiled to WebAssembly",
-  "module": "build/es/Box2D.js",
-  "main": "build/umd/Box2D.js",
+  "module": "entry/es/entry.js",
+  "main": "entry/umd/entry.js",
   "files": [
     "Box2DModule.d.ts",
     "Box2DModuleAugmentations.d.ts",
-    "build/Box2D.d.ts",
-    "build/es/Box2D.js",
-    "build/es/Box2D.wasm",
-    "build/umd/Box2D.js",
-    "build/umd/Box2D.wasm"
+    "entry/es/entry.js",
+    "entry/umd/entry.js",
+    "build/common/Box2D.d.ts",
+    "build/flavour/standard/es/Box2D.js",
+    "build/flavour/standard/es/Box2D.wasm",
+    "build/flavour/standard/umd/Box2D.js",
+    "build/flavour/standard/umd/Box2D.wasm",
+    "build/flavour/simd/es/Box2D.simd.js",
+    "build/flavour/simd/es/Box2D.simd.wasm",
+    "build/flavour/simd/umd/Box2D.simd.js",
+    "build/flavour/simd/umd/Box2D.simd.wasm"
   ],
   "types": "Box2DModule.d.ts",
   "repository": {
@@ -26,7 +32,8 @@
     "webidl-to-ts": "workspace:*"
   },
   "dependencies": {
-    "@types/emscripten": "^1.39.4"
+    "@types/emscripten": "^1.39.4",
+    "wasm-feature-detect": "^1.2.11"
   },
   "author": "Alex Birch",
   "license": "Zlib"

--- a/integration-test/public/index.html
+++ b/integration-test/public/index.html
@@ -10,7 +10,7 @@
 	<link rel='stylesheet' href='global.css'>
 	<link rel='stylesheet' href='build/bundle.css'>
 
-  <script defer src='build/bundle.js'></script>
+  <script defer src='build/main.js' type='module'></script>
 </head>
 
 <body>

--- a/integration-test/rollup.config.js
+++ b/integration-test/rollup.config.js
@@ -14,10 +14,11 @@ export default {
 	input: 'src/main.ts',
 	output: {
 		sourcemap: true,
-		format: 'iife',
+		format: 'esm',
 		name: 'app',
-		file: 'public/build/bundle.js'
+		dir: 'public/build'
 	},
+  // inlineDynamicImports: true,
 	plugins: [
 		svelte({
 			// enable run-time checks when not in production
@@ -48,7 +49,11 @@ export default {
 		// In dev mode, call `npm run start` once
 		// the bundle has been generated
 		!production && serve({
-      contentBase: ['public', 'node_modules/box2d-wasm/build/es'],
+      contentBase: [
+        'public',
+        'node_modules/box2d-wasm/build/flavour/standard/es',
+        'node_modules/box2d-wasm/build/flavour/simd/es'
+      ],
       port: 4000
     }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,10 +2,12 @@ importers:
   box2d-wasm:
     dependencies:
       '@types/emscripten': 1.39.4
+      wasm-feature-detect: 1.2.11
     devDependencies:
       webidl-to-ts: 'link:../webidl-to-ts'
     specifiers:
       '@types/emscripten': ^1.39.4
+      wasm-feature-detect: ^1.2.11
       webidl-to-ts: 'workspace:*'
   integration-test:
     dependencies:
@@ -1743,6 +1745,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+  /wasm-feature-detect/1.2.11:
+    dev: false
+    resolution:
+      integrity: sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w==
   /webidl2/23.13.0:
     dev: true
     resolution:


### PR DESCRIPTION
Add support for [WASM SIMD](https://v8.dev/features/simd).

This could make some parts of Box2D 4x faster. But probably overall performance change will not be as dramatic as that.

Serving the .wasm asset becomes a bit more complicated, because there are now two (in different directories) that will need to be served.

If you were previously serving:

```
node_modules/box2d-wasm/build/es
```

You should now instead serve:

```
node_modules/box2d-wasm/build/flavour/standard/es
node_modules/box2d-wasm/build/flavour/simd/es
```

To make available the assets `Box2D.wasm` and `Box2D.simd.wasm`. I believe the Emscripten boilerplate expects these to be served from the root of your webserver.

But as usual, you can redirect it to lookup the files from a different location, by overriding `locateFile`:

```js
Box2DFactory({
  /**
   * This is the default implementation of locateFile.
   * Modify this logic if your Box2D.wasm lives in a different directory.
   */
  locateFile: (url, scriptDirectory) => `${scriptDirectory}${url}`
})
```