### PR TITLE
Expose methods

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,9 +61,7 @@
         "--loader",
         "ts-node/esm",
         "--experimental-specifier-resolution=node",
-        "--harmony",
-        "-r",
-        "source-map-support/register"
+        "--harmony"
       ],
       "skipFiles": [
         "<node_internals>/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 See https://github.com/Birch-san/box2d-wasm/releases
 
+# v7.0.0
+
+Exposed:
+
+- `b2BodyDef#enabled` attribute (resolves https://github.com/Birch-san/box2d-wasm/issues/38)
+- `b2Body#ApplyLinearImpulseToCenter` method (resolves https://github.com/Birch-san/box2d-wasm/issues/36)
+
+
+
+Deleted (unreachable) type `JSContactListenerWithoutSolveCallbacks` (resolves https://github.com/Birch-san/box2d-wasm/issues/35); the performance problem it was designed to solve (eliminating WASM->JS calls) is [not a problem nowadays](https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%F0%9F%8E%89/). Prefer `JSContactListener`.
+
 # v6.0.4
 
 Added `.d.ts` declarations accompanying `entry.js`, `Box2D.js` and `Box2D.simd.js` (in case anybody wants to bypass the Node module specifier or the entrypoint and import an asset directly).

--- a/box2d-wasm/.gitignore
+++ b/box2d-wasm/.gitignore
@@ -7,11 +7,15 @@
 /dist/Box2D.d.ts
 /dist/es/Box2D.js
 /dist/es/Box2D.wasm
+/dist/es/Box2D.wasm.map
 /dist/es/Box2D.simd.js
 /dist/es/Box2D.simd.wasm
+/dist/es/Box2D.simd.wasm.map
 /dist/umd/Box2D.js
 /dist/umd/Box2D.wasm
+/dist/umd/Box2D.wasm.map
 /dist/umd/Box2D.simd.js
 /dist/umd/Box2D.simd.wasm
+/dist/umd/Box2D.simd.wasm.map
 # integration test for AMD modules which I didn't feel like putting anywhere more formal
 /amd/

--- a/box2d-wasm/Box2D.idl
+++ b/box2d-wasm/Box2D.idl
@@ -233,32 +233,33 @@ interface b2Body {
   b2Fixture CreateFixture(b2FixtureDef def);
   b2Fixture CreateFixture(b2Shape shape, float density);
   void DestroyFixture(b2Fixture fixture);
-  void SetTransform([Ref] b2Vec2 position, float angle);
+  void SetTransform([Const, Ref] b2Vec2 position, float angle);
   [Const, Ref] b2Transform GetTransform();
   [Const, Ref] b2Vec2 GetPosition();
   float GetAngle();
   [Const, Ref] b2Vec2 GetWorldCenter();
   [Const, Ref] b2Vec2 GetLocalCenter();
-  void SetLinearVelocity([Ref] b2Vec2 v);
-  [Value] b2Vec2 GetLinearVelocity();
+  void SetLinearVelocity([Const, Ref] b2Vec2 v);
+  [Const, Ref] b2Vec2 GetLinearVelocity();
   void SetAngularVelocity(float omega);
   float GetAngularVelocity();
-  void ApplyForce([Ref] b2Vec2 force, [Ref] b2Vec2 point, boolean awake);
-  void ApplyForceToCenter([Ref] b2Vec2 force, boolean awake);
+  void ApplyForce([Const, Ref] b2Vec2 force, [Const, Ref] b2Vec2 point, boolean wake);
+  void ApplyForceToCenter([Const, Ref] b2Vec2 force, boolean wake);
   void ApplyTorque(float torque, boolean awake);
-  void ApplyLinearImpulse([Ref] b2Vec2 impulse, [Ref] b2Vec2 point, boolean awake);
-  void ApplyAngularImpulse(float impulse, boolean awake);
+  void ApplyLinearImpulse([Const, Ref] b2Vec2 impulse, [Const, Ref] b2Vec2 point, boolean wake);
+  void ApplyLinearImpulseToCenter([Const, Ref] b2Vec2 impulse, boolean wake);
+  void ApplyAngularImpulse(float impulse, boolean wake);
   float GetMass();
   float GetInertia();
   void GetMassData(b2MassData data);
-  void SetMassData(b2MassData data);
+  void SetMassData([Const] b2MassData data);
   void ResetMassData();
-  [Value] b2Vec2 GetWorldPoint([Ref] b2Vec2 localPoint);
-  [Value] b2Vec2 GetWorldVector([Ref] b2Vec2 localVector);
-  [Value] b2Vec2 GetLocalPoint([Ref] b2Vec2 worldPoint);
-  [Value] b2Vec2 GetLocalVector([Ref] b2Vec2 worldVector);
-  [Value] b2Vec2 GetLinearVelocityFromWorldPoint([Ref] b2Vec2 worldPoint);
-  [Value] b2Vec2 GetLinearVelocityFromLocalPoint([Ref] b2Vec2 localPoint);
+  [Value] b2Vec2 GetWorldPoint([Const, Ref] b2Vec2 localPoint);
+  [Value] b2Vec2 GetWorldVector([Const, Ref] b2Vec2 localVector);
+  [Value] b2Vec2 GetLocalPoint([Const, Ref] b2Vec2 worldPoint);
+  [Value] b2Vec2 GetLocalVector([Const, Ref] b2Vec2 worldVector);
+  [Value] b2Vec2 GetLinearVelocityFromWorldPoint([Const, Ref] b2Vec2 worldPoint);
+  [Value] b2Vec2 GetLinearVelocityFromLocalPoint([Const, Ref] b2Vec2 localPoint);
   float GetLinearDamping();
   void SetLinearDamping(float linearDamping);
   float GetAngularDamping();
@@ -277,9 +278,13 @@ interface b2Body {
   boolean IsEnabled();
   void SetFixedRotation(boolean flag);
   boolean IsFixedRotation();
+  // a const overload also exists, which we cannot easily expose
   b2Fixture GetFixtureList();
+  // a const overload also exists, which we cannot easily expose
   b2JointEdge GetJointList();
+  // a const overload also exists, which we cannot easily expose
   b2ContactEdge GetContactList();
+  // a const overload also exists, which we cannot easily expose
   b2Body GetNext();
   [Ref] b2BodyUserData GetUserData();
   b2World GetWorld();
@@ -306,6 +311,7 @@ interface b2BodyDef {
   attribute boolean awake;
   attribute boolean fixedRotation;
   attribute boolean bullet;
+  attribute boolean enabled;
   [Value] attribute b2BodyUserData userData;
   attribute float gravityScale;
 };

--- a/box2d-wasm/Box2D.idl
+++ b/box2d-wasm/Box2D.idl
@@ -46,15 +46,6 @@ interface JSContactListener {
   void PostSolve(b2Contact contact, [Const] b2ContactImpulse impulse);
 };
 
-// provided for efficiency in the case where you do not use PreSolve/PostSolve
-[JSImplementation="b2ContactListener"]
-interface JSContactListenerWithoutSolveCallbacks {
-  void JSContactListener();
-
-  void BeginContact(b2Contact contact);
-  void EndContact(b2Contact contact);
-};
-
 interface b2World {
   void b2World([Const, Ref] b2Vec2 gravity);
   void SetDestructionListener(b2DestructionListener listener);

--- a/box2d-wasm/glue_stub.js
+++ b/box2d-wasm/glue_stub.js
@@ -370,3 +370,146 @@ Module['allocateArray'] = (ctor, elementSizeBytes, elements=1) => {
   const bodyB_p = getPointerFromUnion(bodyB);
   _emscripten_bind_b2AngularStiffness_6(stiffness_p, damping_p, frequencyHertz, dampingRatio, bodyA_p, bodyB_p);
 };
+
+/**
+ * Calling `new` on an Emscripten object does two things:
+ * - allocates memory on the emscripten heap with {@link Box2D.malloc}()
+ * - creates an Emscripten-wrapped JS object using {@link Box2D.wrapPointer}().
+ * 
+ * When you're done with the Emscripten-wrapped JS object, you should {@link Box2D.destroy}() it.
+ * destroy() does two things:
+ * - invokes the class's __destroy__, which performs {@link Box2D.free}()
+ *   - this frees the dynamically-allocated memory from the WASM heap
+ * - deletes from the class's cache, the reference it retains to the Emscripten-wrapped JS object
+ *   - this eliminates a JS memory leak
+ * 
+ * There's a couple of gaps here.
+ * - how should we clean up after we ourselves invoke wrapPointer()?
+ * - how should we clean up after we receive an Emscripten-wrapped JS object from a method?
+ * 
+ * LeakMitigator provides helper methods to solve those gaps.
+ * 
+ * @example
+ * // This example demonstrates how to use recordLeak/freeLeaked to free many references in one go
+ * import Box2DFactory from 'box2d-wasm';
+ * const { b2BodyDef, b2Vec2, b2World, getPointer, LeakMitigator }: typeof Box2D & EmscriptenModule = await Box2DFactory()
+ * const { freeLeaked, recordLeak } = new LeakMitigator()
+ * 
+ * // we invoked `new`; we should `destroy()` when we're done with it
+ * const gravity = new b2Vec2(0, 10)
+ * 
+ * // b2World takes a copy-by-value of gravity; we are done with it
+ * const world = new b2World(gravity)
+ * // free from WASM heap + delete cached JS reference
+ * destroy(gravity)
+ * 
+ * const bd_ground = new b2BodyDef()
+ * 
+ * // world#CreateBody() returns a JS object built via wrapPointer
+ * // b2Body::__cache__ retains a reference to the object
+ * const ground: Box2D.b2Body = recordLeak(world.CreateBody(bd_ground))
+ * 
+ * // if we have created all the bodies we need from this template, we are free to destroy it.
+ * // world#CreateBody() does not retain any reference to it (it accepts b2BodyDef via copy-by-value)
+ * destroy(bd_ground)
+ * 
+ * // fast-forward to later, where we tear down the Box2D experiment...
+ * 
+ * for (let body: Box2D.b2Body = world.GetBodyList(); getPointer(body) !== getPointer(NULL); body = body.GetNext()) {
+ *   // this b2Body was created with b2World#CreateBody(), so Box2D manages the memory, not us.
+ *   // we should not use destroy(body). instead we should use b2World#DestroyBody()
+ *   // this also destroys all fixtures on the body.
+ *   world.DestroyBody(body);
+ * }
+ * 
+ * // delete from the __cache__ of applicable b2* classes:
+ * // every JS object reference that this LeakMitigator recorded
+ * freeLeaked()
+ * @example
+ * // This example demonstrates how to use freeFromCache to free a single reference
+ * import Box2DFactory from 'box2d-wasm';
+ * const { b2BodyDef, b2Vec2, b2World, getPointer, LeakMitigator }: typeof Box2D & EmscriptenModule = await Box2DFactory()
+ * const { freeFromCache } = LeakMitigator
+ * 
+ * // we invoked `new`; we should `destroy()` when we're done with it
+ * const gravity = new b2Vec2(0, 10)
+ * 
+ * // b2World takes a copy-by-value of gravity; we are done with it
+ * const world = new b2World(gravity)
+ * // free from WASM heap + delete cached JS reference
+ * destroy(gravity)
+ * 
+ * const bd_ground = new b2BodyDef()
+ * 
+ * // world#CreateBody() returns a JS object built via wrapPointer
+ * // b2Body::__cache__ retains a reference to the object
+ * const ground: Box2D.b2Body = world.CreateBody(bd_ground)
+ * 
+ * // if we have created all the bodies we need from this template, we are free to destroy it.
+ * // world#CreateBody() does not retain any reference to it (it accepts b2BodyDef via copy-by-value)
+ * destroy(bd_ground)
+ * 
+ * // when we are done with `ground`:
+ * world.DestroyBody(ground);
+ * // delete the reference to the `ground` JS object in b2Body's __cache__
+ * freeFromCache(ground);
+ */
+Module['LeakMitigator'] = class LeakMitigator {
+  constructor() {
+    this.instances = new Map()
+  }
+
+  /**
+   * Convenience method to free an object from an Emscripten class's __cache__
+   */
+  static freeFromCache(
+    instance,
+    b2Class = Module['getClass'](instance)
+  ) {
+    const cache = Module['getCache'](b2Class)
+    delete cache[Module['getPointer'](instance)]
+  }
+
+  /**
+   * wrap this around any Emscripten method which returns an object.
+   * records the instance, so that we can free it from cache later
+   */
+  recordLeak(
+    instance,
+    b2Class = Module['getClass'](instance)
+  ) {
+    const instances = this.instances.get(b2Class) ?? new Set()
+    instances.add(instance)
+    this.instances.set(b2Class, instances)
+    return instance
+  }
+
+  /**
+   * prefer this over {@link Box2D.wrapPointer}.
+   * records the instance that's created, so that we can free it from cache later
+   */
+  safeWrapPointer(
+    pointer,
+    targetType
+  ) {
+    return this.recordLeak(
+      Module['wrapPointer'](pointer, targetType),
+      targetType
+    )
+  }
+
+  /**
+   * access the cache structure of each Emscripten class for which we recorded instances,
+   * then free from cache every instance that we recorded.
+   */
+  freeLeaked() {
+    // using Array#forEach because acorn optimizer couldn't parse the for..of
+    this.instances.entries().forEach(([b2Class, instances]) => {
+      const cache = Module['getCache'](b2Class)
+      for (const instance of instances) {
+        delete cache[Module['getPointer'](instance)]
+      }
+    })
+    this.instances.clear()
+  }
+}

--- a/box2d-wasm/package.json
+++ b/box2d-wasm/package.json
@@ -38,7 +38,7 @@
     "webidl-to-ts": "workspace:*"
   },
   "dependencies": {
-    "@types/emscripten": "^1.39.4"
+    "@types/emscripten": "^1.39.6"
   },
   "author": "Alex Birch",
   "license": "Zlib"

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -1,16 +1,24 @@
-## Memory model
+# Memory model
+
+## Every `new` needs a corresponding `destroy()`
+
+_See the next section for an explanation of what we're doing with `LeakMitigator`'s `recordLeak` / `freeLeaked`._
 
 Any object that you create with `new`: it is your responsibility to destroy that object via `destroy()`:
 
 ```js
 import Box2DFactory from 'box2d-wasm';
-const { b2_dynamicBody, b2BodyDef, b2Vec2, b2PolygonShape, b2World, destroy, getPointer, NULL } = await Box2DFactory();
+const { b2_dynamicBody, b2BodyDef, b2Vec2, b2PolygonShape, b2World, destroy, getPointer, LeakMitigator, NULL } = await Box2DFactory();
+const { freeLeaked, recordLeak } = new LeakMitigator()
 
+// Emscripten class constructors invoke Emscripten's malloc(), which grows the WASM heap
 const gravity = new b2Vec2(0, 10);
-// in this particular case, Box2D does **not** retain a reference to our b2Vec2
-// it takes a copy instead.
+// in this particular case, Box2D does **not** retain a reference to our b2Vec2;
+// it takes a copy.
 const world = new b2World(gravity);
-// we are finished using the b2Vec2, and we know Box2D will not use it either.
+// we are finished using the b2Vec2
+// destroy() frees the malloc()ed memory from the WASM heap, and deletes the reference
+// to the gravity JS object retained in b2Vec2::__cache__.
 destroy(gravity);
 
 // now we'll demonstrate how a b2Vec2 can be re-used (instead of throwing it away immediately)
@@ -22,13 +30,19 @@ bd.set_position(tmp);
 // it's safe to destroy tmp now, but let's keep it alive so we can re-use it.
 
 // b2BodyDef is a _template_. b2World#CreateBody() takes a _copy_ of it.
-const body = world.CreateBody(bd);
+// Box2D will use its internal object allocators (which *may* invoke malloc() -- growing
+// the WASM heap -- or may re-use older memory that's since been marked as reusable).
+// we use recordLeak() to track the fact that world#CreateBody() stores a reference to
+// the b2Body JS object in b2Body::__cache__ -- we will evict this cache entry later.
+const body = recordLeak(world.CreateBody(bd));
+// world#CreateBody() does not retain a reference to `bd`; safe to destroy
 destroy(bd);
 
 // b2PolygonShape is a _template_. b2Body#CreateFixture() takes a _copy_ of it.
 const square = new b2PolygonShape();
 square.SetAsBox(1, 1);
-body.CreateFixture(square, 1);
+// any method which return a JS object, needs to be recorded in our LeakMitigator
+recordLeak(body.CreateFixture(square, 1));
 // it's safe to destroy square now, because Box2D took copies of it rather than retaining a reference
 destroy(square);
 
@@ -41,20 +55,118 @@ destroy(tmp);
 
 world.Step(1/60, 1, 1);
 
+// strictly speaking we could consider wrapping world#GetBodyList() and body#GetNext()
+// with recordLeak() (because they're methods which return JS objects)
+// but we already recorded these bodies in our LeakMitigator when we received them
+// via world#CreateBody()
 for (let body = world.GetBodyList(); getPointer(body) !== getPointer(NULL); body = body.GetNext()) {
-  // Box2D owns the b2Vec2 returned by b2Body#GetPosition(); we do not need to destroy it
-  const { x, y } = body.GetPosition();
+  // what happens when we invoke a getter which returns an object?
+  // that's right, we need recordLeak().
+  // but we don't need `destroy()` (this b2Vec2 wasn't created via `new`).
+  const position = recordLeak(body.GetPosition());
+  const { x, y } = position;
   console.log(x, y);
 
-  // now let's tidy up
+  // now let's delete the body.
+  // we don't need `destroy()` (this b2Body wasn't created via `new`).
+  // this b2Body was created with b2World#CreateBody(), so Box2D manages the memory, not us.
+  // this also destroys all fixtures on the body, and b2Vec2s like the "position" we read above.
+  world.DestroyBody(body);
+}
+
+// we are finished using the world
+destroy(world);
+
+freeLeaked();
+```
+
+## JS objects returned by functions require manual eviction from Emscripten cache
+
+Calling `new` on an Emscripten object does two things:  
+- allocates memory on the WASM heap with `malloc()`
+- creates an Emscripten-wrapped JS object using `wrapPointer()`.
+
+When you're done with the Emscripten-wrapped JS object, you should `destroy()` it.
+`destroy()` does two things:  
+- invokes the class's `__destroy__`, which performs `free()`
+  - this frees the dynamically-allocated memory from the WASM heap
+- deletes from the class's cache, the reference it retains to the Emscripten-wrapped JS object
+  - this eliminates a JS memory leak
+
+There's a couple of gaps here.  
+- how should we clean up after we ourselves invoke `wrapPointer()`?
+- how should we clean up after we receive an Emscripten-wrapped JS object from a method?
+
+`LeakMitigator` provides helper methods to solve those gaps.
+
+### using `freeFromCache` to free a single reference
+
+```js
+import Box2DFactory from 'box2d-wasm';
+const { b2BodyDef, b2Vec2, b2World, getPointer, LeakMitigator } = await Box2DFactory()
+const { freeFromCache } = LeakMitigator
+
+// we invoked `new`; we should `destroy()` when we're done with it
+const gravity = new b2Vec2(0, 10)
+
+// b2World takes a copy-by-value of gravity; we are done with it
+const world = new b2World(gravity)
+// free from WASM heap + delete cached JS reference
+destroy(gravity)
+
+const bd_ground = new b2BodyDef()
+
+// world#CreateBody() returns a JS object built via wrapPointer
+// b2Body::__cache__ retains a reference to the object
+const ground = world.CreateBody(bd_ground)
+
+// if we have created all the bodies we need from this template, we are free to destroy it.
+// world#CreateBody() does not retain any reference to it (it accepts b2BodyDef via copy-by-value)
+destroy(bd_ground)
+
+// when we are done with `ground`:
+world.DestroyBody(ground);
+// delete the reference to the `ground` JS object in b2Body's __cache__
+freeFromCache(ground);
+```
+
+### using `recordLeak`/`freeLeaked` to free many references in one go
+
+```js
+import Box2DFactory from 'box2d-wasm';
+const { b2BodyDef, b2Vec2, b2World, getPointer, LeakMitigator } = await Box2DFactory()
+const { freeLeaked, recordLeak } = new LeakMitigator()
+
+// we invoked `new`; we should `destroy()` when we're done with it
+const gravity = new b2Vec2(0, 10)
+
+// b2World takes a copy-by-value of gravity; we are done with it
+const world = new b2World(gravity)
+// free from WASM heap + delete cached JS reference
+destroy(gravity)
+
+const bd_ground = new b2BodyDef()
+
+// world#CreateBody() returns a JS object built via wrapPointer
+// b2Body::__cache__ retains a reference to the object
+const ground = recordLeak(world.CreateBody(bd_ground))
+
+// if we have created all the bodies we need from this template, we are free to destroy it.
+// world#CreateBody() does not retain any reference to it (it accepts b2BodyDef via copy-by-value)
+destroy(bd_ground)
+
+// fast-forward to later, where we tear down the Box2D experiment...
+
+for (let body = world.GetBodyList(); getPointer(body) !== getPointer(NULL); body = body.GetNext()) {
   // this b2Body was created with b2World#CreateBody(), so Box2D manages the memory, not us.
   // we should not use destroy(body). instead we should use b2World#DestroyBody()
   // this also destroys all fixtures on the body.
   world.DestroyBody(body);
 }
 
-// we are finished using the world
-destroy(world);
+// delete from the __cache__ of applicable b2* classes:
+// every JS object reference that this LeakMitigator recorded
+freeLeaked()
 ```
 
 ## Memory re-use
@@ -65,4 +177,5 @@ This is not necessarily a memory leak; your next `b2World#CreateBody()` may be a
 
 A consequence of this re-use is that you should avoid assigning custom properties to objects that you receive via factory functions such as `b2World#CreateBody()`. See the [managing user data](user-data.md) docs for further detail.
 
-`new` grows the heap, and `destroy()` shrinks the heap. I've measured this and the heap didn't always go back down to quite the same size. Maybe my measurements are wrong though.
+`new` grows the heap (because it calls `malloc()`), and  
+`destroy()` shrinks the heap (because it calls `free()`).

--- a/integration-test-backend/package.json
+++ b/integration-test-backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "start": "node --loader ts-node/esm --experimental-specifier-resolution=node --harmony -r source-map-support/register src/index.ts",
+    "start": "node --loader ts-node/esm --experimental-specifier-resolution=node --harmony src/index",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src/**/*.ts"
@@ -23,8 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "eslint": "^7.11.0",
-    "source-map-support": "^0.5.19",
-    "ts-node": "^10.0.0",
+    "ts-node": "^10.4.0",
     "typescript": "^4.3.0"
   },
   "dependencies": {

--- a/integration-test-backend/src/index.ts
+++ b/integration-test-backend/src/index.ts
@@ -1,7 +1,20 @@
 import Box2DFactory from 'box2d-wasm';
 import { assertFloatEqual } from './assertFloatEqual';
 
-const { b2BodyDef, b2_dynamicBody, b2PolygonShape, b2Vec2, b2World }: typeof Box2D & EmscriptenModule = await Box2DFactory();
+const {
+  b2BodyDef,
+  b2_dynamicBody,
+  b2PolygonShape,
+  b2Vec2,
+  b2World,
+  destroy,
+  getPointer,
+  LeakMitigator,
+  NULL
+}: typeof Box2D & EmscriptenModule = await Box2DFactory();
+
+const { freeFromCache } = LeakMitigator;
+const { recordLeak, freeLeaked } = new LeakMitigator();
 
 const gravity = new b2Vec2(0, 10);
 const world = new b2World(gravity);
@@ -16,10 +29,13 @@ const bd = new b2BodyDef();
 bd.set_type(b2_dynamicBody);
 bd.set_position(zero);
 
-const body = world.CreateBody(bd);
-body.CreateFixture(square, 1);
+const body = recordLeak(world.CreateBody(bd));
+destroy(bd);
+freeFromCache(body.CreateFixture(square, 1));
+destroy(square);
 body.SetTransform(zero, 0);
 body.SetLinearVelocity(zero);
+destroy(zero);
 body.SetAwake(true);
 body.SetEnabled(true);
 
@@ -41,5 +57,14 @@ for (let i=0; i<iterations; i++) {
   }
   world.Step(timeStepMillis, velocityIterations, positionIterations);
 }
+
+destroy(gravity);
+
+for (let body = recordLeak(world.GetBodyList()); getPointer(body) !== getPointer(NULL); body = recordLeak(body.GetNext())) {
+  world.DestroyBody(body);
+}
+
+destroy(world);
+freeLeaked();
 
 console.log(`👍 Ran ${iterations} iterations of a falling body. Body had the expected position on each iteration.`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,11 @@
 importers:
   box2d-wasm:
     dependencies:
-      '@types/emscripten': 1.39.4
+      '@types/emscripten': 1.39.6
     devDependencies:
       webidl-to-ts: 'link:../webidl-to-ts'
     specifiers:
-      '@types/emscripten': ^1.39.4
+      '@types/emscripten': ^1.39.6
       webidl-to-ts: 'workspace:*'
   integration-test:
     dependencies:
@@ -230,10 +230,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-DLsoZH9z5DLDi6qMbXKqeqlQLK1h3rfR9dK+KX8UJSGHJylvIZPOCQEKr/d/FClPoZE/eHOa3+e270eUJCUTog==
-  /@types/emscripten/1.39.4:
+  /@types/emscripten/1.39.6:
     dev: false
     resolution:
-      integrity: sha512-k3LLVMFrdNA9UCvMDPWMbFrGPNb+GcPyw29ktJTo1RCN7RmxFG5XzPZcPKRlnLuLT/FRm8wp4ohvDwNY7GlROQ==
+      integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==
   /@types/estree/0.0.39:
     dev: true
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 4.4.1_2196fd0119f017e301a06eb3953d355c
       '@typescript-eslint/parser': 4.4.1_eslint@7.11.0+typescript@4.3.5
       eslint: 7.11.0
-      source-map-support: 0.5.19
-      ts-node: 10.0.0_ae070899a1185038810c6e69a96767bc
+      ts-node: 10.4.0_ae070899a1185038810c6e69a96767bc
       typescript: 4.3.5
     specifiers:
       '@types/node': ^14.11.8
@@ -66,8 +65,7 @@ importers:
       '@typescript-eslint/parser': ^4.4.1
       box2d-wasm: 'workspace:*'
       eslint: ^7.11.0
-      source-map-support: ^0.5.19
-      ts-node: ^10.0.0
+      ts-node: ^10.4.0
       typescript: ^4.3.0
   webidl-to-ts:
     devDependencies:
@@ -116,6 +114,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  /@cspotcode/source-map-consumer/0.8.0:
+    dev: true
+    engines:
+      node: '>= 12'
+    resolution:
+      integrity: sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+  /@cspotcode/source-map-support/0.7.0:
+    dependencies:
+      '@cspotcode/source-map-consumer': 0.8.0
+    dev: true
+    engines:
+      node: '>=12'
+    resolution:
+      integrity: sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   /@eslint/eslintrc/0.1.3:
     dependencies:
       ajv: 6.12.6
@@ -218,10 +230,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
-  /@tsconfig/node16/1.0.1:
+  /@tsconfig/node16/1.0.2:
     dev: true
     resolution:
-      integrity: sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==
+      integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
   /@tsconfig/svelte/1.0.10:
     dev: true
     resolution:
@@ -487,6 +499,12 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     resolution:
       integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  /acorn-walk/8.2.0:
+    dev: true
+    engines:
+      node: '>=0.4.0'
+    resolution:
+      integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
   /acorn/7.4.1:
     dev: true
     engines:
@@ -494,6 +512,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+  /acorn/8.6.0:
+    dev: true
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
   /ajv/6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1849,27 +1874,27 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
-  /ts-node/10.0.0_ae070899a1185038810c6e69a96767bc:
+  /ts-node/10.4.0_ae070899a1185038810c6e69a96767bc:
     dependencies:
+      '@cspotcode/source-map-support': 0.7.0
       '@tsconfig/node10': 1.0.8
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
-      '@tsconfig/node16': 1.0.1
+      '@tsconfig/node16': 1.0.2
       '@types/node': 14.11.8
+      acorn: 8.6.0
+      acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      source-map-support: 0.5.19
       typescript: 4.3.5
       yn: 3.1.1
     dev: true
-    engines:
-      node: '>=12.0.0'
     hasBin: true
     peerDependencies:
-      '@swc/core': '>=1.2.45'
-      '@swc/wasm': '>=1.2.45'
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
       typescript: '>=2.7'
     peerDependenciesMeta:
@@ -1878,7 +1903,7 @@ packages:
       '@swc/wasm':
         optional: true
     resolution:
-      integrity: sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==
+      integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
   /ts-node/9.1.1_typescript@4.0.3:
     dependencies:
       arg: 4.1.3


### PR DESCRIPTION
Closes https://github.com/Birch-san/box2d-wasm/issues/38  
Closes https://github.com/Birch-san/box2d-wasm/issues/36  
Closes https://github.com/Birch-san/box2d-wasm/issues/35

Exposed:

- `b2BodyDef#enabled` attribute (resolves https://github.com/Birch-san/box2d-wasm/issues/38)
- `b2Body#ApplyLinearImpulseToCenter` method (resolves https://github.com/Birch-san/box2d-wasm/issues/36)

Added `LeakMitigator` for freeing retained references from Emscripten's JS object caches.

Deleted (unreachable) type `JSContactListenerWithoutSolveCallbacks` (resolves https://github.com/Birch-san/box2d-wasm/issues/35); the performance problem it was designed to solve (eliminating WASM->JS calls) is [not a problem nowadays](https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%F0%9F%8E%89/). Prefer `JSContactListener`.